### PR TITLE
Move tokenizer to CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![embedders](https://uploads-ssl.webflow.com/61e47fafb12bd56b40022a49/626ee1c35a3abf0ca872486d_embedder-banner.png)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)
-[![pypi 0.0.11](https://img.shields.io/badge/pypi-0.0.11-red.svg)](https://pypi.org/project/embedders/0.0.11/)
+[![pypi 0.0.12](https://img.shields.io/badge/pypi-0.0.12-red.svg)](https://pypi.org/project/embedders/0.0.12/)
 
 # ⚗️ embedders
 With `embedders`, you can easily convert your texts into sentence- or token-level embeddings within a few lines of code. Use cases for this include similarity search between texts, information extraction such as named entity recognition, or basic text classification.

--- a/embedders/extraction/contextual.py
+++ b/embedders/extraction/contextual.py
@@ -114,8 +114,8 @@ class TransformerTokenEmbedder(TokenEmbedder):
     def _get_char_level_embeddings(
         self, document: str
     ) -> List[List[Tuple[int, int, List[List[float]]]]]:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        encoded = self.transformer_tokenizer(document, return_tensors="pt").to(device)
+        encoded = self.transformer_tokenizer(
+            document, return_tensors="pt").to(self.device)
         tokens = encoded.encodings[0]
         num_tokens = len(
             set(tokens.words[1:-1])

--- a/embedders/extraction/contextual.py
+++ b/embedders/extraction/contextual.py
@@ -74,7 +74,7 @@ class TransformerTokenEmbedder(TokenEmbedder):
         )
         self.transformer_tokenizer = AutoTokenizer.from_pretrained(
             config_string
-        )
+        ).to(self.device)
         self.model = AutoModel.from_pretrained(
             config_string, output_hidden_states=True
         ).to(self.device)

--- a/embedders/extraction/contextual.py
+++ b/embedders/extraction/contextual.py
@@ -74,7 +74,7 @@ class TransformerTokenEmbedder(TokenEmbedder):
         )
         self.transformer_tokenizer = AutoTokenizer.from_pretrained(
             config_string
-        ).to(self.device)
+        )
         self.model = AutoModel.from_pretrained(
             config_string, output_hidden_states=True
         ).to(self.device)
@@ -114,8 +114,11 @@ class TransformerTokenEmbedder(TokenEmbedder):
     def _get_char_level_embeddings(
         self, document: str
     ) -> List[List[Tuple[int, int, List[List[float]]]]]:
-        encoded = self.transformer_tokenizer.encode_plus(
-            document, return_tensors="pt")
+        # encoded = self.transformer_tokenizer.encode_plus(
+        #     document, return_tensors="pt")
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        encoded = self.transformer_tokenizer(document, return_tensors="pt").to(device)
         tokens = encoded.encodings[0]
         num_tokens = len(
             set(tokens.words[1:-1])

--- a/embedders/extraction/contextual.py
+++ b/embedders/extraction/contextual.py
@@ -114,9 +114,6 @@ class TransformerTokenEmbedder(TokenEmbedder):
     def _get_char_level_embeddings(
         self, document: str
     ) -> List[List[Tuple[int, int, List[List[float]]]]]:
-        # encoded = self.transformer_tokenizer.encode_plus(
-        #     document, return_tensors="pt")
-
         device = "cuda" if torch.cuda.is_available() else "cpu"
         encoded = self.transformer_tokenizer(document, return_tensors="pt").to(device)
         tokens = encoded.encodings[0]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, "README.md")) as file:
 
 setup(
     name="embedders",
-    version="0.0.11",
+    version="0.0.12",
     author="Johannes Hötter",
     author_email="johannes.hoetter@kern.ai",
     description="High-level API for creating sentence and token embeddings",


### PR DESCRIPTION
When running the 0.0.11 version of embedders library on GPU, the following error happens:

```INFO:     10.55.1.72:38340 - "GET /classification/recommend/TEXT HTTP/1.1" 200 OK
INFO:     10.55.1.72:38394 - "GET /classification/recommend/TEXT HTTP/1.1" 200 OK
INFO:     10.55.1.72:38408 - "POST /extraction/encode HTTP/1.1" 200 OK
Downloading: 100%|██████████| 28.0/28.0 [00:00<00:00, 25.3kB/s]
Downloading: 100%|██████████| 570/570 [00:00<00:00, 495kB/s]
Downloading: 100%|██████████| 226k/226k [00:00<00:00, 515kB/s] 
Downloading: 100%|██████████| 455k/455k [00:00<00:00, 1.03MB/s]
Downloading: 100%|██████████| 420M/420M [00:07<00:00, 62.6MB/s] 
Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertModel: ['cls.predictions.transform.dense.weight', 'cls.predictions.transform.LayerNorm.bias', 'cls.predictions.decoder.weight', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.bias', 'cls.seq_relationship.weight', 'cls.predictions.transform.dense.bias', 'cls.seq_relationship.bias']
- This IS expected if you are initializing BertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing BertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Traceback (most recent call last):
  File "/program/./controller.py", line 228, in run_encoding
    for pair in generate_batches(
  File "/program/./controller.py", line 53, in generate_batches
    yield {"record_ids": record_batch, "embeddings": next(embedding_batches)}
  File "/usr/local/lib/python3.8/dist-packages/embedders/extraction/reduce.py", line 33, in _reduce
    for batch_idx, batch in enumerate(
  File "/usr/local/lib/python3.8/dist-packages/embedders/extraction/contextual.py", line 88, in _encode
    char_level_embs = self._get_char_level_embeddings(str(doc))
  File "/usr/local/lib/python3.8/dist-packages/embedders/extraction/contextual.py", line 124, in _get_char_level_embeddings
    output = self.model(**encoded)
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/transformers/models/bert/modeling_bert.py", line 989, in forward
    embedding_output = self.embeddings(
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/transformers/models/bert/modeling_bert.py", line 214, in forward
    inputs_embeds = self.word_embeddings(input_ids)
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/sparse.py", line 158, in forward
    return F.embedding(
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/functional.py", line 2183, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper__index_select)
```

I assumed the problem could be solved by moving the tokenizer as well. https://github.com/huggingface/transformers/issues/16359 suggest using `.to(device)` instead of `.encode_plus()` in this context.

It is working for me now, but I don't know the theory well enough to understand if the output is exactly the same. Please help! 😄 

P.S. Please squash when merging.