### PR TITLE
Add support for OpenAI, Azure, Cohere, Replicate Embedding Models - using litellm 

### DIFF
--- a/embedders/classification/contextual.py
+++ b/embedders/classification/contextual.py
@@ -6,6 +6,7 @@ from spacy.tokens.doc import Doc
 import torch
 import openai
 from openai import error as openai_error
+from litellm import embedding
 import cohere
 
 
@@ -121,11 +122,11 @@ class OpenAISentenceEmbedder(SentenceEmbedder):
             documents_batch = [doc.replace("\n", " ") for doc in documents_batch]
             try:
                 if self.use_azure:
-                    response = openai.Embedding.create(
+                    response = embedding(
                         input=documents_batch, engine=self.model_name
                     )
                 else:
-                    response = openai.Embedding.create(
+                    response = embedding(
                         input=documents_batch, model=self.model_name
                     )
                 embeddings = [entry["embedding"] for entry in response["data"]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 transformers>=4.6.0,<5.0.0
 openai
 cohere
+litellm


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/
**TLDR**
- You get support for all liteLLM supported embedding models 
- I noticed you had a class for `Cohere` embeddings, instead of maintaining classes, liteLLM can be the simple abstraction to select your models. Simply pass the `model` param when calling `embedding` and liteLLM manages calling the correct API & translation of input + output

Here's a sample of how it's used:

```
from litellm import embedding

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

# openai call
response = embedding(input=[text], model="text-embedding-ada-002")

# azure call
response = embedding(input=[text], model="azure-embedding-model", azure=True)

# replicate call
response = embedding(input=[text], model="replicate/all-mpnet-base-v2:b6b7585c9640cd7a9572c6e129c9549d79c9c31f0d3fdce7baac7c67ca38f305")


```
